### PR TITLE
Differenciate between external pages and internal pages.

### DIFF
--- a/components/link/link.js
+++ b/components/link/link.js
@@ -2,10 +2,13 @@ import React from 'react'
 import { ApolloConsumer } from 'react-apollo'
 import { css } from '@emotion/core'
 import { NextLink, A } from '../styled'
-import prefetch from '../../lib/prefetch'
 
-const Link = ({ label, url, apolloQuery, customCss, target }) => (
-  <NextLink url={url} prefetch>
+const isExternal = function(url) {
+  return /https?/.test(url)
+}
+
+const Link = ({ label, url, apolloQuery, customCss, target, prefetch }) => (
+  <NextLink url={url} prefetch={!isExternal(url)}>
     <A
       css={css`
         ${customCss};

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -7,8 +7,8 @@ const isExternal = function(url) {
   return /https?/.test(url)
 }
 
-const Link = ({ label, url, apolloQuery, customCss, target, prefetch }) => (
-  <NextLink url={url} prefetch={!isExternal(url)}>
+const Link = ({ label, url, apolloQuery, customCss, target }) => (
+  <NextLink url={url} shouldPrefetch={!isExternal(url)}>
     <A
       css={css`
         ${customCss};

--- a/components/link/linkList.jsx
+++ b/components/link/linkList.jsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import Link from './link'
-// import Link from 'next/link'
 import { UL, LI } from '../styled'
-import prefetch from '../../lib/prefetch'
 
 const common = `
   position: relative;
@@ -68,9 +66,6 @@ const LinkList = ({ links }) => (
         }}
       >
         <Link {...item} customCss={customLinkStyle} />
-        {/* <Link prefetch href={item.url}>
-          <a onMouseOver={() => prefetch('/product?sku=0001')}>{item.label}</a>
-        </Link> */}
       </LI>
     ))}
   </UL>

--- a/components/styled/link.js
+++ b/components/styled/link.js
@@ -11,8 +11,8 @@ const A = styled('a')(({ customCss }) => ({
   }
 }))
 
-const NextLink = ({ children, url, prefetch, passHref, apolloQuery }) => (
-  <Link href={url} passHref={passHref} prefetch>
+const NextLink = ({ children, url, passHref, apolloQuery, shouldPrefetch }) => (
+  <Link href={url} passHref={passHref} prefetch={shouldPrefetch}>
     {children}
   </Link>
 )
@@ -27,7 +27,7 @@ A.defaultProps = {
 NextLink.defaultProps = {
   children: null,
   url: '',
-  prefetch: false,
+  shouldPrefetch: true,
   passHref: true
 }
 


### PR DESCRIPTION
At the moment prefetching happens on all pages and on external returns a 404, as expected. 